### PR TITLE
app.yaml application is deprecated with gcloud

### DIFF
--- a/appengine-push/README.md
+++ b/appengine-push/README.md
@@ -35,7 +35,7 @@ TODO(tmatsuo): Better implementation for devserver.
 ## Configuration
 
 - Edit app.yaml
-    - Replace 'your-application-id' with your real application id.
+    - Replace 'your-application-id' with your real application id. If you will use the new gcloud preview feature, you may comment out this entire line by prefxing the line with a '#'. The application field is deprecated and not used by gcloud. 
 
 - Edit constants.py
     - Replace '{AN_UNIQUE_TOKEN}' with your random unique token.
@@ -57,7 +57,7 @@ $ appcfg.py --oauth2 update .
 or you can use gcloud preview feature
 
 ```
-$ gcloud preview app deploy .
+$ gcloud preview app deploy . --project your-application-id
 ```
 
 ## Run the application locally


### PR DESCRIPTION
If gcloud is used, app.yaml's application is ignored and should be specified on the command-line (or set as the project default).