### PR TITLE
Use /_ah/push-handlers/ prefix for the push endpoint.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
           ./google-cloud-sdk/install.sh --usage-reporting false --path-update false --command-completion false &&
           cd ${TRAVIS_BUILD_DIR};
       fi
-    - gcloud -q components update
+    - gcloud -q components update --version 104.0.0
     - gcloud -q config set app/use_appengine_api true
     - if [ -a client-secret.json ]; then
           gcloud auth activate-service-account --key-file client-secret.json;

--- a/appengine-push/app.yaml
+++ b/appengine-push/app.yaml
@@ -5,8 +5,9 @@ threadsafe: true
 handlers:
 - url: /js
   static_dir: js
-- url: /receive_message.*
+- url: /_ah/push-handlers/.*
   script: main.APPLICATION
+  login: admin
 - url: /.*
   script: main.APPLICATION
 

--- a/appengine-push/main.py
+++ b/appengine-push/main.py
@@ -167,5 +167,5 @@ APPLICATION = webapp2.WSGIApplication(
         ('/', InitHandler),
         ('/fetch_messages', FetchMessages),
         ('/send_message', SendMessage),
-        ('/receive_message', ReceiveMessage),
+        ('/_ah/push-handlers/receive_message', ReceiveMessage),
     ], debug=True)

--- a/appengine-push/pubsub_utils.py
+++ b/appengine-push/pubsub_utils.py
@@ -81,9 +81,10 @@ def get_app_subscription_name():
 
 
 def get_app_endpoint_url():
-    return 'https://{}-dot-{}.appspot.com/receive_message?token={}'.format(
-        get_current_version(), get_project_id(),
-        constants.SUBSCRIPTION_UNIQUE_TOKEN)
+    return ('https://{}-dot-{}.appspot.com/_ah/push-handlers'
+            '/receive_message?token={}').format(
+            get_current_version(), get_project_id(),
+            constants.SUBSCRIPTION_UNIQUE_TOKEN)
 
 
 def get_project_id():

--- a/appengine-push/test_deploy.py
+++ b/appengine-push/test_deploy.py
@@ -74,3 +74,13 @@ class IntegrationTestCase(unittest.TestCase):
                 found = True
                 break
         self.assertTrue(found)
+
+    def test_receive_message(self):
+        """Test that the /_ah/push-handlers/ is protected."""
+        (resp, _) = self.http.request(
+            url_for('/_ah/push-handlers/receive_message'), 'POST',
+            headers={'Content-Length': '0'})
+        self.assertEquals(
+            302, resp.status,
+            'status for /_ah/push-handlers/receive_message should be 302, '
+            'actual: {}'.format(resp.status))


### PR DESCRIPTION
/_ah/push-handlers is now protected as admin-required for public, but it's accessible from the Cloud Pub/Sub push service.